### PR TITLE
Update Super Gem Fighter Mini Mix detector.

### DIFF
--- a/sgemf.inf
+++ b/sgemf.inf
@@ -1,18 +1,17 @@
 start=Start,raw,eq,0xFF8188,153,8
-player1=P1 Win,raw,gts,0xFF87A1,0,8
-player2=P2 Win,raw,gts,0xFF8BA1,0,8
+player1=P1 Win,raw,eq,0xFF8BA4,0,8
+player2=P2 Win,raw,eq,0xFF87A4,0,8
 char1=P1Char,raw,char,0xFF8781,0,8
 char2=P2Char,raw,char,0xFF8B81,0,8
-char=11,Akuma
 char=0,Ryu
 char=1,Ken
-char=10,Dan
 char=2,Chun-Li
 char=3,Sakura
 char=4,Morrigan
 char=5,Hsien-Ko
 char=6,Felicia
 char=7,Tessa
-char=9,Zangief
 char=8,Ibuki
-
+char=9,Zangief
+char=10,Dan
+char=11,Akuma


### PR DESCRIPTION
The existing detector was correctly written to look at each player's win count, but this game has a bug where if a round ends in a draw, P2 immediately gets a game win. This is obviously not so great for score-keeping...

The new detector looks at each player's 'lives', which are essentially the inverse of round wins. When P2 has 0 lives remaining, P1 wins the game, and vice-versa. This works regardless of how many lives players start with (which is a dipswitch setting). To verify, just start a match and let the timer run out so that the round is a draw. With the old detector, P2 will get a game win. With the new one, this will not happen.

I also put the characters listed in the detector in order.